### PR TITLE
Add flash-container function to makefile

### DIFF
--- a/FC_GEN2/Makefile
+++ b/FC_GEN2/Makefile
@@ -55,6 +55,9 @@ DEVICE ?= STM32F767ZI
 flash: build
 	st-flash --reset write $(FIRMWARE) 0x08000000
 
+flash-container: build-container
+	st-flash --reset write $(FIRMWARE) 0x08000000
+
 clean:
 	rm -rf $(BUILD_DIR)
 


### PR DESCRIPTION
Use the `make flash-container` to build the docker container and flash the microcontroller.