### PR TITLE
Add windows machine build and flashing instructions

### DIFF
--- a/FC_GEN2/README.md
+++ b/FC_GEN2/README.md
@@ -1,3 +1,24 @@
+# Windows 10 Building and Flashing
+
+Required downloads:
+- WSL2
+- Docker - https://www.docker.com/products/docker-desktop/
+- Make - https://cmake.org/download/
+- Stlink - https://github.com/stlink-org/stlink
+
+Add your public SSH key to your GitHub profile.
+
+Navigate to the `~/.ssh/` directory on your machine and enter the command `ssh-keygen`.
+Press enter to skip each prompt and use the default settings.
+
+Copy the contents of the newly generated `id_rsa.pub` file and navigate to the settings of your GitHub account. In the SSH and GPG keys tab, click New SSH key and add the string that you copied.
+
+Ensure that the Modules directory in the FC_GEN2 project folder has the appropriate submodules. If not, enter the following command to pull them from GitHub:
+
+`git submodule update --init --recursive`
+
+---
+
 # STM32 project template
 
 This repository holds all the possible tools and templates for building and developing STM32 projects.  

--- a/FC_GEN2/README.md
+++ b/FC_GEN2/README.md
@@ -13,7 +13,7 @@ Press enter to skip each prompt and use the default settings.
 
 Copy the contents of the newly generated `id_rsa.pub` file and navigate to the settings of your GitHub account. In the SSH and GPG keys tab, click New SSH key and add the string that you copied.
 
-Ensure that the Modules directory in the FC_GEN2 project folder has the appropriate submodules. If not, enter the following command to pull them from GitHub:
+Ensure you have updated all your Git submodules. The `build-container` command will do this automatically, but this will also help Intellisense resolve symbols.
 
 `git submodule update --init --recursive`
 

--- a/FC_GEN2/README.md
+++ b/FC_GEN2/README.md
@@ -1,21 +1,7 @@
-# Windows 10 Building and Flashing
+# Local Setup Documentation
 
-Required downloads:
-- WSL2
-- Docker - https://www.docker.com/products/docker-desktop/
-- Make - https://cmake.org/download/
-- Stlink - https://github.com/stlink-org/stlink
-
-Add your public SSH key to your GitHub profile.
-
-Navigate to the `~/.ssh/` directory on your machine and enter the command `ssh-keygen`.
-Press enter to skip each prompt and use the default settings.
-
-Copy the contents of the newly generated `id_rsa.pub` file and navigate to the settings of your GitHub account. In the SSH and GPG keys tab, click New SSH key and add the string that you copied.
-
-Ensure you have updated all your Git submodules. The `build-container` command will do this automatically, but this will also help Intellisense resolve symbols.
-
-`git submodule update --init --recursive`
+- [Git Setup](./docs/setup-git.md)
+- [Windows Setup](./docs/setup-windows.md)
 
 ---
 

--- a/FC_GEN2/docs/setup-git.md
+++ b/FC_GEN2/docs/setup-git.md
@@ -1,0 +1,18 @@
+# Git SSH Setup
+
+This guide is to create an SSH key to be connected to a GitHub profile in order to clone the project using SSH.
+
+## Setting up an SSH key using ssh-keygen
+
+Navigate to the `~/.ssh/` directory on your machine and enter the command `ssh-keygen`.
+Press enter to skip each prompt and use the default settings.
+
+## Connecting your SSH key with your GitHub profile
+
+Copy the contents of the newly generated `id_rsa.pub` file and navigate to the settings of your GitHub account. In the SSH and GPG keys tab, click New SSH key and add the string that you copied.
+
+## Cloning the project using SSH
+
+```bash
+git clone git@github.com:macformula/front_controller.git
+```

--- a/FC_GEN2/docs/setup-windows.md
+++ b/FC_GEN2/docs/setup-windows.md
@@ -1,0 +1,22 @@
+# Setting up a Windows device to build and flash the FC_GEN2 project
+
+This document is a basic guide for setting up a Windows device to build and flash the FC_GEN2 project.
+
+## Required Downloads
+
+- [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install)
+- [Docker](https://www.docker.com/products/docker-desktop/)
+- [CMake](https://cmake.org/download/)
+- [Stlink](https://github.com/stlink-org/stlink)
+
+Docker, CMake, and Stlink should be added to your PATH. If not done so automatically by the installer, refer to [this video](https://youtu.be/KbnHT1SoOj0?list=PLEg2mgYz66IOcHRvvUDf9O1ZCGy58M1Bt&t=421) for more information about adding the above tools to your PATH.
+
+## Frequent Issues
+
+Ensure you have updated all your Git submodules. The `build-container` command will do this automatically, but this will also help Intellisense resolve symbols.
+
+```bash
+git submodule update --init --recursive
+```
+
+The docker daemon must be running for building and flashing, this can be done simply by starting the docker desktop application.


### PR DESCRIPTION
When building and flashing the FC_GEN2 project locally on a Windows 10 machine, we found that the following steps needed to be taken:
- The project needed to be cloned using SSH.
- Stlink is required for flashing.
- There may be issues importing the submodules, the fix for this is included.

These steps are to be added to the README documentation.